### PR TITLE
CI: add coverage tests

### DIFF
--- a/.github/grcov.yml
+++ b/.github/grcov.yml
@@ -1,0 +1,14 @@
+ignore-not-existing: true
+branch: true
+llvm: true
+filter: covered
+output-type: lcov
+ignore:
+  - "/*"
+  - "../*"
+  - "C:/*"
+  - ".cargo/*"
+  - ".git/*"
+  - ".github/*"
+# doc: https://github.com/mozilla/grcov#usage
+# example: https://github.com/actions-rs/grcov/blob/master/README.md#example

--- a/.github/grcov.yml
+++ b/.github/grcov.yml
@@ -10,5 +10,8 @@ ignore:
   - ".cargo/*"
   - ".git/*"
   - ".github/*"
+  # ignore because can't build with profile feature
+  - "bcs/*"
+  - "crypto/*"
 # doc: https://github.com/mozilla/grcov#usage
 # example: https://github.com/actions-rs/grcov/blob/master/README.md#example

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --no-fail-fast
+          args: --all --all-features --no-fail-fast --exclude=bcs
 
       - id: coverage
         name: coverage analysis with grcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,11 @@ jobs:
         os:
           - ubuntu-latest
 
+    env:
+      SKIP_WASM_BUILD: 1
+      CARGO_INCREMENTAL: 0
+      RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -120,30 +125,39 @@ jobs:
       - name: cargo clean
         run: cargo clean
 
+      - name: get latest grcov binary
+        uses: dsaltares/fetch-gh-release-asset@0.0.5
+        with:
+          repo: mozilla/grcov
+          version: "latest"
+          file: grcov-linux-x86_64.tar.bz2
+
+      - name: unpack grcov release binary
+        run: |
+          tar -xvf grcov-linux-x86_64.tar.bz2
+          sudo chown runner ./grcov && chmod +x ./grcov
+          cp grcov ~/.cargo/bin/grcov
+          rm grcov-linux-x86_64.tar.bz2
+
       - name: cargo build tests +profile
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --all-features --no-fail-fast
-        env:
-          SKIP_WASM_BUILD: 1
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
 
       - id: coverage
-        name: coverage grcov
+        name: coverage analysis with grcov
         uses: actions-rs/grcov@v0.1
         with:
           config: .github/grcov.yml
 
-      - name: make artifact
+      - name: make report artifact
         uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report
           path: ${{ steps.coverage.outputs.report }}
 
-      - name: upload to Coveralls
+      - name: upload report to Coveralls
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,3 +90,62 @@ jobs:
         run: |
           cd mvm
           cargo build --package mvm --no-default-features --features="std"
+
+  coverage:
+    name: "Coverage"
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: cargo clean
+        run: cargo clean
+
+      - name: cargo build tests +profile
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --all-features --no-fail-fast
+        env:
+          SKIP_WASM_BUILD: 1
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+
+      - id: coverage
+        name: coverage grcov
+        uses: actions-rs/grcov@v0.1
+        with:
+          config: .github/grcov.yml
+
+      - name: make artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: code-coverage-report
+          path: ${{ steps.coverage.outputs.report }}
+
+      - name: upload to Coveralls
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,8 +129,8 @@ jobs:
         env:
           SKIP_WASM_BUILD: 1
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
 
       - id: coverage
         name: coverage grcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,6 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
 
     steps:


### PR DESCRIPTION
- add coverage tests with [grcov](https://github.com/mozilla/grcov)
- remove unnecessary checks

Also it uploads reports to Coveralls.io.
To make this works we could sign up on Coveralls and give access to the repo.