### PR TITLE
CI: enable prereleases for get-dove

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Dove executable
         uses: pontem-network/get-dove@main
         with:
+          prerelease: true
           version: ${{ matrix.dove }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -94,6 +95,7 @@ jobs:
       - name: Dove executable
         uses: pontem-network/get-dove@main
         with:
+          prerelease: true
           version: ${{ matrix.dove }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes [this](https://github.com/pontem-network/sp-move-vm/runs/3472069026#step:5:5)